### PR TITLE
svg files are treated as xml files

### DIFF
--- a/modules/openfed_features/openfed_svg_file/src/Plugin/Field/FieldFormatter/OpenfedSvgFileFormatter.php
+++ b/modules/openfed_features/openfed_svg_file/src/Plugin/Field/FieldFormatter/OpenfedSvgFileFormatter.php
@@ -73,12 +73,11 @@ class OpenfedSvgFileFormatter extends FileFormatterBase {
             $dom = new \DomDocument();
             libxml_use_internal_errors(TRUE);
             $dom->loadXML($svg_file);
-            $svg_data = $dom->saveXML();
             if (isset($dom->documentElement)) {
               $dom->documentElement->setAttribute('height', $attributes['height']);
               $dom->documentElement->setAttribute('width', $attributes['width']);
-              $svg_data = $dom->saveXML();
             }
+            $svg_data = $dom->C14N();
           }
         }
 


### PR DESCRIPTION
This create issue in W3C validation 

> Saw <?. Probable cause: Attempt to use an XML processing instruction in HTML. (XML processing instructions are not supported in HTML.)
>At line 387, column 116
> field__item"><?xml version="1

Solution is to use [C14N](https://www.php.net/manual/en/domnode.c14n.php) method instead.

This is currently tested